### PR TITLE
TN DNS seeders

### DIFF
--- a/domain/dagconfig/params.go
+++ b/domain/dagconfig/params.go
@@ -283,7 +283,11 @@ var TestnetParams = Params{
 	Net:         appmessage.Testnet,
 	RPCPort:     "18210",
 	DefaultPort: "18211",
-	DNSSeeds:    []string{}, // NOTE: Will be added later with privacy feature.
+	DNSSeeds:    []string{
+		// Official DNS seeders.
+		"testnet-dnsseed-1.spectre-network.org",
+		"testnet-dnsseed-2.spectre-network.org",
+	},
 
 	// DAG parameters
 	GenesisBlock:                    &testnetGenesisBlock,

--- a/domain/dagconfig/params.go
+++ b/domain/dagconfig/params.go
@@ -283,7 +283,7 @@ var TestnetParams = Params{
 	Net:         appmessage.Testnet,
 	RPCPort:     "18210",
 	DefaultPort: "18211",
-	DNSSeeds:    []string{
+	DNSSeeds: []string{
 		// Official DNS seeders.
 		"testnet-dnsseed-1.spectre-network.org",
 		"testnet-dnsseed-2.spectre-network.org",


### PR DESCRIPTION
* Added official testnet DNS seeders `testnet-dnsseed-1.spectre-network.org` and `testnet-dnsseed-2.spectre-network.org`.